### PR TITLE
Global Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ The following fields can be specified in the config file
 - **privateKeyFile** - RSA key, you must upload a public key to the remote server before attempting to upload any content.
 - **remoteDir** - directory on the server, where files are going to be uploaded
 
+### Global Configuration
+
+You can specify the path to a global config file in the `EASYUPLOAD_CONFIG` environment variable. 
+These options are applied to every project using easyupload, but can be overwritten by the local `ezupload.json` config file.
+
+See the [arguments](#arguments) section for more information on how to disable this mechanism.
+
 ## Arguments
 **`--config -c`** - specify custom configuration file
 
 **`--log-type -log`** - set a log type: "all", "none", "progress" or "files", defaults to "all"
+
+**`--ignore-global-config -i`** - don't pull options from the global config file

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,20 +28,9 @@ function parseArgsToOptions(raw: string[]): Options {
     }
 }
 
-function checkConfig(config: Config) {
-    if (!config.host) {
-        throw new Error('config error: specify the "host" field')
-    } else if (!config.password && !config.privateKeyFile) {
-        throw new Error('config error: specify "password" or "privateKeyFile" field')
-    } else if (!config.path || !config.remoteDir) {
-        throw new Error('config error: both "path" and "remoteDir" fields are required')
-    }
-}
-
-export function cli(args) {
+export function cli(args: string[]) {
     const options = parseArgsToOptions(args)
-    const config: Config = JSON.parse(fs.readFileSync(options.configFile, "utf-8"))
-    checkConfig(config)
+    const config = loadConfig(options)
 
     const sftpConfig = {
         ...config,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,23 +2,29 @@ import arg from "arg"
 import fs from "fs"
 
 import SftUpload from "sftp-upload"
+import { Log, Options } from "./index"
+import { loadConfig } from "./config"
 
-function parseArgsToOptions(raw): Options {
+function parseArgsToOptions(raw: string[]): Options {
     const args = arg(
         {
             "--config": String,
             "--log-type": String,
+            "--ignore-global-config": Boolean,
 
             "-c": "--config",
             "-log": "--log-type",
+            "-i": "--ignore-global-config"
         },
         {
             argv: raw.slice(2),
         }
     )
+
     return {
         configFile: args["--config"] || "ezupload.json",
         logType: (args["--log-type"] as Log) || "all",
+        ignoreGlobalConfig: !!args["--ignore-global-config"]
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,41 @@
+import { Config, Options } from "./index"
+import fs from "fs"
+
+export function loadConfig(options: Options): Config {
+    const global = loadGlobal()
+    const local = loadLocal(options)
+    const config = options.ignoreGlobalConfig ? local : { ...global, ...local }
+
+    validate(config)
+    return config as Config
+}
+
+function validate(config: Partial<Config>) {
+    if (!config.host) {
+        throw new Error('config error: specify the "host" field')
+    } else if (!config.password && !config.privateKeyFile) {
+        throw new Error('config error: specify "password" or "privateKeyFile" field')
+    } else if (!config.path || !config.remoteDir) {
+        throw new Error('config error: both "path" and "remoteDir" fields are required')
+    }
+}
+
+function loadGlobal() {
+    return parseFile(process.env.EASYUPLOAD_CONFIG)
+}
+
+function loadLocal({ configFile }: Options) {
+    return parseFile(configFile || "ezupload.json")
+}
+
+function parseFile(path?: string): Config | {} {
+    try {
+        const file = fs.readFileSync(path, "utf-8")
+        const config = JSON.parse(file)
+
+        if (config) return config
+    } catch (e) {
+    }
+
+    return {}
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,7 @@ export type Config = {
 export type Options = {
     logType: Log
     configFile: string
+    ignoreGlobalConfig: boolean
 }
 
 export type Log = "all" | "none" | "files" | "progress"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-type Config = {
+export type Config = {
     host: string
     username: string
     password?: string
@@ -8,9 +8,9 @@ type Config = {
     privateKeyFile?: string
 }
 
-type Options = {
+export type Options = {
     logType: Log
     configFile: string
 }
 
-type Log = "all" | "none" | "files" | "progress"
+export type Log = "all" | "none" | "files" | "progress"


### PR DESCRIPTION
The global configuration adds another layer of configuration on top of the local `ezupload.json` file. The variables set in this global config can be overwritten by the local config. Using the `--ignore-global-config` command line flag, the program will not use the global config and instead pull all its settings from the local config.